### PR TITLE
Lectern rebranding

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
             </div>
             <div style="margin-top: 1rem;">
                 <img src="https://img.shields.io/badge/release-in%20progress-blue">
-                <img src="https://img.shields.io/github/license/Dispenser-Projects/Minecraft-Block-Renderer" />
+                <img src="https://img.shields.io/github/license/Dispenser-Projects/Lectern" />
                 <a href="https://discord.gg/J7f4WynJq9" class="no-underline">
                     <img src="https://img.shields.io/discord/125723125685026816?color=blue&label=Discord" />
                 </a>
@@ -48,7 +48,7 @@
             </div>
             <div style="margin-top: 1rem;">
                 <a href="https://github.com/Dispenser-Projects/Minecraft-Block-Renderer/releases" class="no-underline">
-                    <img src="https://img.shields.io/github/v/release/Dispenser-Projects/Minecraft-Block-Renderer" />
+                    <img src="https://img.shields.io/github/v/release/Dispenser-Projects/Lectern" />
                 </a>
             </div>
             <p style="opacity: 0.5;">
@@ -66,12 +66,12 @@
     
     <div id="box-block-renderer" class="box-window draggable">
         <div class="box-bar">
-            <span>Block Renderer</span>
+            <span>Lectern</span>
         </div>
         <div class="box-content">
             <div style="display: flex; justify-content: space-between;">
                 <div>
-                    <a href="https://github.com/theogiraudet/Minecraft-Block-Renderer" class="btn btn-outline">
+                    <a href="https://github.com/Dispenser-Projects/Lectern" class="btn btn-outline">
                         Github
                     </a>
                 </div>
@@ -79,7 +79,7 @@
                     <svg style="width: 1rem; transform: scale(1.3);" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
                 </a>
             </div>
-            <iframe id="iframe-block-renderer" src="https://dispenser.gunivers.net/block-renderer/"></iframe>
+            <iframe id="iframe-block-renderer" src="https://dispenser.gunivers.net/lectern/"></iframe>
         </div>
     </div>
 


### PR DESCRIPTION
Je profite de la migration vers le nouvel hébergement pour changer l'emplacement d'hébergement de Lectern de `dispenser.gunivers.net/block-renderer` à `dispenser.gunivers.net/lectern`. 
Une redirection sera en place tout de même au cas où pour les éventuels utilisateurs de l'ancienne URL.